### PR TITLE
Adding Preset QA folks to a Preset-QA label, for easier tracking

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,10 @@ exports.USER_ORG_XREF = {
   'michael-s-molina': 'Turing',
   maloun96: 'Flexiana',
   geido: 'Flexiana',
-  nikolagigic: 'Flexiana'
+  nikolagigic: 'Flexiana',
+  'jinghua-qa': 'Preset-QA',
+  'rosemarie-chiu': 'Preset-QA',
+  'adam-stasiak': 'Preset-QA'
 };
 exports.ORG_GROUPS = {
   Flexiana: 'preset-ext',


### PR DESCRIPTION
We now have three QA folks working on Superset, here at Preset. This PR adds a `Preset-QA` label for these folks, so that we can more easily track their filed regressions and maintain them on a Github Project.